### PR TITLE
Remove -ansi flag from gcc compiler flags

### DIFF
--- a/CONFIG/src/atlcomp.txt
+++ b/CONFIG/src/atlcomp.txt
@@ -40,99 +40,99 @@
 #
 # Core2/Corei1/Corei2/Corei3/Corei4/Corei4X
 MACH=Corei3,Corei3EP,Corei4,Corei4X OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,gcc,xcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -O2'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -O2'
 MACH=Corei4,Corei4X OS=all LVL=1100 COMPS=dmc,smc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -O2 -fschedule-insns'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -O2 -fschedule-insns'
 MACH=Corei2 OS=Win9x,WinNT,Win64 LVL=1005 COMPS=smc,dmc,skc,dkc,icc
-   'gcc-4' '-ansi -fomit-frame-pointer -mfpmath=sse -O2 -fno-schedule-insns2'
+   'gcc-4' ' -fomit-frame-pointer -mfpmath=sse -O2 -fno-schedule-insns2'
 MACH=Corei2 OS=ALL LVL=1000 COMPS=dmc
-   'gcc' '-ansi -O1 -mfpmath=sse -mavx'
+   'gcc' ' -O1 -mfpmath=sse -mavx'
 MACH=Corei2 OS=ALL LVL=1000 COMPS=smc,skc,dkc,icc,gcc,xcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -O2 -fno-schedule-insns2'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -O2 -fno-schedule-insns2'
 MACH=Corei1 OS=Win9x,WinNT,Win64 LVL=1005 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc-4' '-ansi -fomit-frame-pointer -mfpmath=sse -O2 -fno-schedule-insns2'
+   'gcc-4' ' -fomit-frame-pointer -mfpmath=sse -O2 -fno-schedule-insns2'
 MACH=Corei1 OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -O2 -fno-schedule-insns2'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -O2 -fno-schedule-insns2'
 MACH=Core2 OS=Win9x,WinNT,Win64 LVL=1005 COMPS=smc,dmc,skc,dkc,icc
-   'gcc-4' '-ansi -fomit-frame-pointer -mfpmath=sse -O2'
+   'gcc-4' ' -fomit-frame-pointer -mfpmath=sse -O2'
 MACH=Core2 OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -O2'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -O2'
 MACH=Atom OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc
-   'gcc' '-ansi -O3 -fno-schedule-insns2 -funroll-all-loops -fno-tree-ch'
+   'gcc' ' -O3 -fno-schedule-insns2 -funroll-all-loops -fno-tree-ch'
 MACH=Atom OS=ALL LVL=1000 COMPS=icc,gcc
-   'gcc' '-ansi -O'
+   'gcc' ' -O'
 # Generic x86 defaults for building portable, low-performance libs
 MACH=x86x87 OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
+   'gcc' ' -fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
 MACH=x86x87,x86SSE1 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
 MACH=x86SSE1 OS=ALL LVL=1000 COMPS=dmc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
+   'gcc' ' -fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
 MACH=x86SSE1 OS=ALL LVL=1000 COMPS=smc,skc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -O2'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -O2'
 MACH=x86SSE1 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
 MACH=x86SSE2 OS=ALL LVL=1000 COMPS=smc,skc,dmc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -O2'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -O2'
 MACH=x86SSE2 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-fomit-frame-pointer -mfpmath=sse -O2'
 MACH=x86SSE3 OS=ALL LVL=1000 COMPS=dmc,smc,dkc,skc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -O2'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -O2'
 MACH=x86SSE3 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-fomit-frame-pointer -mfpmath=sse -O2'
 # P4E, P4
 MACH=P4E,P4 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-O2 -fomit-frame-pointer -mfpmath=sse'
 MACH=P4E OS=ALL LVL=1000 COMPS=skc,dkc,icc
-   'gcc' '-ansi -O2 -fomit-frame-pointer -mfpmath=sse'
+   'gcc' ' -O2 -fomit-frame-pointer -mfpmath=sse'
 MACH=P4E,P4 OS=ALL LVL=1000 COMPS=smc,dmc
-   'gcc' '-ansi -O2 -fomit-frame-pointer -mfpmath=sse -fno-schedule-insns -fno-optimize-register-move'
+   'gcc' ' -O2 -fomit-frame-pointer -mfpmath=sse -fno-schedule-insns -fno-optimize-register-move'
 MACH=P4E,P4 OS=Win9x,WinNT,Win64 LVL=1005 COMPS=smc,dmc
-   'gcc-4' '-ansi -O2 -fomit-frame-pointer -mfpmath=sse -fno-schedule-insns -fno-optimize-register-move'
+   'gcc-4' ' -O2 -fomit-frame-pointer -mfpmath=sse -fno-schedule-insns -fno-optimize-register-move'
 MACH=P4E,P4 OS=ALL LVL=1000 COMPS=skc,dkc,icc
-   'gcc-4' '-ansi -O2 -fomit-frame-pointer -mfpmath=sse'
+   'gcc-4' ' -O2 -fomit-frame-pointer -mfpmath=sse'
 # Hammer
 MACH=HAMMER OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-fomit-frame-pointer -mfpmath=387 -O2'
 MACH=HAMMER OS=Win9x,WinNT,Win64 LVL=1005 COMPS=smc,dmc,skc,dkc,icc
-   'gcc-4' '-ansi -fomit-frame-pointer -mfpmath=387 -O2'
+   'gcc-4' ' -fomit-frame-pointer -mfpmath=387 -O2'
 MACH=HAMMER OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=387 -O2'
+   'gcc' ' -fomit-frame-pointer -mfpmath=387 -O2'
 # PPRO,PII,PIII,K7
 MACH=PPRO,PII,PIII,K7 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
 MACH=PPRO,PII,PIII,K7 OS=Win9x,WinNT,Win64 LVL=1005 COMPS=smc,dmc,skc,dkc,icc
-   'gcc-4' '-ansi -fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
+   'gcc-4' ' -fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
 MACH=PPRO,PII,PIII,P4,P4E,K7 OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
+   'gcc' ' -fomit-frame-pointer -mfpmath=387 -O2 -falign-loops=4'
 # CoreSolo,CoreDuo
 MACH=CoreSolo,CoreDuo OS=WinNT,Win9x,Win64 LVL=1005 COMPS=smc,dmc,skc,dkc,icc
-   'gcc-4' '-ansi -fomit-frame-pointer -O3 -mfpmath=387'
+   'gcc-4' ' -fomit-frame-pointer -O3 -mfpmath=387'
 MACH=CoreSolo,CoreDuo OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -O3 -mfpmath=387'
+   'gcc' ' -fomit-frame-pointer -O3 -mfpmath=387'
 # 3rd generation opteron (Barcelona and descendents)
 MACH=AMD64K10h OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-fomit-frame-pointer -mfpmath=sse -O2'
 MACH=AMD64K10h OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -O2'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -O2'
 MACH=AMD64K10h OS=Win9x,WinNT,Win64 LVL=1005 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -O2'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -O2'
 MACH=AMDDRIVER OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc' '-ansi -Os -fomit-frame-pointer'
+   'gcc' ' -Os -fomit-frame-pointer'
 MACH=AMDDOZER OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,gcc
-   'gcc' '-ansi -fomit-frame-pointer -mfpmath=sse -mfma4 -O2 -fno-tree-loop-optimize'
+   'gcc' ' -fomit-frame-pointer -mfpmath=sse -mfma4 -O2 -fno-tree-loop-optimize'
 # UltraSPARC T2
 MACH=UST2 OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc,icc,xcc,gcc
-   'gcc' '-ansi -mcpu=niagara2 -mtune=niagara2 -Os'
+   'gcc' ' -mcpu=niagara2 -mtune=niagara2 -Os'
 MACH=UST2 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-mcpu=niagara2 -mtune=niagara2 -Os'
 # UltraSPARC III & IV
 MACH=USIII,USIV OS=ALL LVL=1000 COMPS=smc,
-   'gcc' '-ansi -O1 -mcpu=ultrasparc3 -mtune=ultrasparc3 -fschedule-insns -fmodulo-sched'
+   'gcc' ' -O1 -mcpu=ultrasparc3 -mtune=ultrasparc3 -fschedule-insns -fmodulo-sched'
 MACH=USIII,USIV OS=ALL LVL=1000 COMPS=dmc,skc,dkc,icc
-   'gcc' '-ansi -O3 -mcpu=ultrasparc3 -mtune=ultrasparc3 -fno-schedule-insns2 -fschedule-insns'
+   'gcc' ' -O3 -mcpu=ultrasparc3 -mtune=ultrasparc3 -fno-schedule-insns2 -fschedule-insns'
 MACH=USIII,USIV OS=ALL LVL=1000 COMPS=xcc,gcc
-   'gcc' '-ansi -mcpu=ultrasparc3 -mtune=ultrasparc3 -O'
+   'gcc' ' -mcpu=ultrasparc3 -mtune=ultrasparc3 -O'
 MACH=USIII,USIV OS=ALL LVL=1000 COMPS=f77
    'f77' '-dalign -native -xO5'
 MACH=USIII,USIV OS=ALL LVL=100 COMPS=f77
@@ -144,9 +144,9 @@ MACH=USIII,USIV OS=ALL LVL=10 COMPS=f77
 #
 # These gcc 4 default flags will die on gcc3, allowing gcc3's flags to be used
 MACH=IA64Itan,IA64Itan2 OS=ALL LVL=1010 COMPS=smc,dmc,skc,dkc
-   'gcc' '-ansi -fomit-frame-pointer -O2 -fno-tree-loop-optimize'
+   'gcc' ' -fomit-frame-pointer -O2 -fno-tree-loop-optimize'
 MACH=IA64Itan,IA64Itan2 OS=ALL LVL=1000 COMPS=smc,dmc,skc,dkc
-   'gcc' '-ansi -fomit-frame-pointer -O2'
+   'gcc' ' -fomit-frame-pointer -O2'
 MACH=IA64Itan,IA64Itan2 OS=ALL LVL=1010 COMPS=f77
    'gfortran' '-fomit-frame-pointer -O2 -fno-tree-loop-optimize'
 #
@@ -164,7 +164,7 @@ MACH=MIPSR1xK OS=IRIX LVL=1000 COMPS=f77
 # pathcc at -O2 -- seems to be a compiler error
 #
 MACH=MIPSICE9 OS=ALL LVL=500 COMPS=icc,smc,dmc,skc,dkc,xcc,gcc
-   'gcc' '-ansi -O2 -mips64 -march=5kf -mtune=5kf -fno-schedule-insns -fschedule-insns2 -fno-peephole -fno-peephole2'
+   'gcc' ' -O2 -mips64 -march=5kf -mtune=5kf -fno-schedule-insns -fschedule-insns2 -fno-peephole -fno-peephole2'
 MACH=MIPSICE9 OS=ALL LVL=1000 COMPS=f77
    'pathf95' '-march=auto -O2'
 MACH=MIPSICE9 OS=ALL LVL=1 COMPS=skc,dkc
@@ -178,32 +178,32 @@ MACH=MIPSICE9 OS=ALL LVL=1 COMPS=icc,xcc
 # confirmed in gcc 4.3.2.
 #
 MACH=PPCG4 OS=ALL LVL=1000 COMPS=dmc
-   'gcc' '-ansi -Os -maltivec -mabi=altivec -mcpu=7400 -mtune=7400'
+   'gcc' ' -Os -maltivec -mabi=altivec -mcpu=7400 -mtune=7400'
 MACH=PPCG4 OS=ALL LVL=1000 COMPS=smc
-   'gcc' '-ansi -Os -maltivec -mabi=altivec -mcpu=7400 -mtune=7400'
+   'gcc' ' -Os -maltivec -mabi=altivec -mcpu=7400 -mtune=7400'
 MACH=PPCG4 OS=ALL LVL=1000 COMPS=icc,skc,dkc,xcc,gcc
-   'gcc' '-ansi -O3 -maltivec -mabi=altivec -mcpu=7400 -mtune=7400 -fno-schedule-insns -fschedule-insns2'
+   'gcc' ' -O3 -maltivec -mabi=altivec -mcpu=7400 -mtune=7400 -fno-schedule-insns -fschedule-insns2'
 #
 # PowerPC970
 #
 MACH=PPCG5 OS=ALL LVL=1000 COMPS=smc
-   'gcc' '-ansi -Os -mpowerpc64 -maltivec -mabi=altivec -mcpu=970 -mtune=970 -mvrsave -fno-schedule-insns2 -fno-schedule-insns'
+   'gcc' ' -Os -mpowerpc64 -maltivec -mabi=altivec -mcpu=970 -mtune=970 -mvrsave -fno-schedule-insns2 -fno-schedule-insns'
 MACH=PPCG5 OS=ALL LVL=1000 COMPS=dmc,icc,dkc,xcc,gcc
-   'gcc' '-ansi -mpowerpc64 -maltivec -mabi=altivec -mcpu=970 -mtune=970 -O2'
+   'gcc' ' -mpowerpc64 -maltivec -mabi=altivec -mcpu=970 -mtune=970 -O2'
 MACH=PPCG5 OS=ALL LVL=1000 COMPS=skc
-   'gcc' '-ansi -mpowerpc64 -maltivec -mabi=altivec -mcpu=970 -mtune=970 -O2 -mvrsave'
+   'gcc' ' -mpowerpc64 -maltivec -mabi=altivec -mcpu=970 -mtune=970 -O2 -mvrsave'
 MACH=POWER7 OS=ALL LVL=1010 COMPS=icc,smc,dmc,skc,dkc,xcc,gcc
-   'gcc' '-ansi -O2 -mvsx -mcpu=power7 -mtune=power7 -m64 -mvrsave -funroll-all-loops'
+   'gcc' ' -O2 -mvsx -mcpu=power7 -mtune=power7 -m64 -mvrsave -funroll-all-loops'
 MACH=POWER7 OS=ALL LVL=1010 COMPS=f77
    'gfortran' '-O2 -mvsx -mcpu=power7 -mtune=power7 -m64 -mvrsave -funroll-all-loops'
 MACH=POWER8 OS=ALL LVL=1010 COMPS=icc,smc,dmc,skc,dkc,xcc,gcc
-   'gcc' '-ansi -O2 -mvsx -mcpu=power8 -mtune=power8 -m64 -mvrsave -funroll-all-loops'
+   'gcc' ' -O2 -mvsx -mcpu=power8 -mtune=power8 -m64 -mvrsave -funroll-all-loops'
 MACH=POWER8 OS=ALL LVL=1010 COMPS=f77
    'gfortran' '-O2 -mvsx -mcpu=power8 -mtune=power8 -m64 -mvrsave -funroll-all-loops'
 MACH=POWER6 OS=ALL LVL=1010 COMPS=icc,smc,dmc,skc,dkc,xcc,gcc
-   'gcc' '-ansi -mcpu=power6 -mtune=power6 -maltivec -O3 -fno-schedule-insns -fschedule-insns2 -minsert-sched-nops=2'
+   'gcc' ' -mcpu=power6 -mtune=power6 -maltivec -O3 -fno-schedule-insns -fschedule-insns2 -minsert-sched-nops=2'
 MACH=POWER5 OS=ALL LVL=1010 COMPS=icc,smc,dmc,skc,dkc,xcc,gcc
-   'gcc' '-ansi -mcpu=power5 -mtune=power5 -O3 -fno-schedule-insns -fno-rerun-loop-opt'
+   'gcc' ' -mcpu=power5 -mtune=power5 -O3 -fno-schedule-insns -fno-rerun-loop-opt'
 MACH=POWER6 OS=ALL LVL=1010 COMPS=f77
    'gfortran' '-mcpu=power6 -mtune=power6 -maltivec -O3 -fno-schedule-insns -fschedule-insns2 -minsert-sched-nops=2'
 MACH=POWER5 OS=ALL LVL=1010 COMPS=f77
@@ -213,7 +213,7 @@ MACH=POWER7 OS=ALL LVL=1010 COMPS=f77
 MACH=POWER5 OS=ALL LVL=1010 COMPS=f77
    'xlf' '-qtune=pwr5 -qarch=pwr5 -O3 -qmaxmem=-1 -qfloat=hsflt'
 MACH=POWER4 OS=ALL LVL=1010 COMPS=icc,dmc,smc,dkc,skc,xcc,gcc
-   'gcc' '-ansi -mcpu=power4 -mtune=power4 -O3 -fno-schedule-insns -fno-rerun-loop-opt'
+   'gcc' ' -mcpu=power4 -mtune=power4 -O3 -fno-schedule-insns -fno-rerun-loop-opt'
 MACH=POWER4 OS=ALL LVL=1010 COMPS=f77
    'xlf' '-qtune=pwr4 -qarch=pwr4 -O3 -qmaxmem=-1 -qfloat=hsflt'
 #
@@ -271,47 +271,47 @@ MACH=P4,PM OS=WinNT,Win64 LVL=0 COMPS=icc,dmc,smc,dkc,skc,xcc
 # ARM defaults
 #
 MACH=ARMa7,ARMa9,ARMa15 OS=ALL LVL=1000 COMPS=xcc
-   'gcc' '-ansi -O2'
+   'gcc' ' -O2'
 MACH=ARMa7,ARMa9,ARMa15 OS=ALL LVL=1000 COMPS=smc,skc,gcc,icc
-   'gcc' '-ansi -O2 -fselective-scheduling2'
+   'gcc' ' -O2 -fselective-scheduling2'
 MACH=ARMa15 OS=ALL LVL=1000 COMPS=dmc,dkc
-   'gcc' '-ansi -O2 -fno-schedule-insns -fno-schedule-insns2 -fprefetch-loop-arrays'
+   'gcc' ' -O2 -fno-schedule-insns -fno-schedule-insns2 -fprefetch-loop-arrays'
 MACH=ARMa7 OS=ALL LVL=1100 COMPS=dmc
-   'gcc' '-ansi -O2 -mcpu=cortex-a7 -fno-schedule-insns -fselective-scheduling2'
+   'gcc' ' -O2 -mcpu=cortex-a7 -fno-schedule-insns -fselective-scheduling2'
 MACH=ARMa9 OS=ALL LVL=1100 COMPS=dmc
-   'gcc' '-ansi -O3 -mcpu=cortex-a9 -fno-schedule-insns -fno-schedule-insns2'
+   'gcc' ' -O3 -mcpu=cortex-a9 -fno-schedule-insns -fno-schedule-insns2'
 MACH=ARMa9 OS=ALL LVL=1100 COMPS=smc,skc,dkc
-   'gcc' '-ansi -O2 -mcpu=cortex-a9 -fschedule-insns'
+   'gcc' ' -O2 -mcpu=cortex-a9 -fschedule-insns'
 MACH=ARMa7,ARMa9,ARMa15 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-O2'
 #
 # ARM64thund defaults, not tuned, adapted from xgene
 #
 MACH=ARM64thund,ARM64A1100 OS=ALL LVL=1000 COMPS=xcc
-   'gcc' '-ansi -O2'
+   'gcc' ' -O2'
 MACH=ARM64thund,ARM64A1100 OS=ALL LVL=1000 COMPS=icc
-   'gcc' '-ansi,ARM64A1100 -O2'
+   'gcc' ',ARM64A1100 -O2'
 MACH=ARM64thund,ARM64A1100 OS=ALL LVL=1000 COMPS=skc,gcc,dkc
-   'gcc' '-ansi -O3'
+   'gcc' ' -O3'
 MACH=ARM64thund,ARM64A1100 OS=ALL LVL=1000 COMPS=smc
-   'gcc' '-ansi -O2'
+   'gcc' ' -O2'
 MACH=ARM64thund,ARM64A1100 OS=ALL LVL=1000 COMPS=dmc
-   'gcc' '-ansi -O2'
+   'gcc' ' -O2'
 MACH=ARM64thund,ARM64A1100 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-O2'
 #
 # ARM64xgene1 defaults
 #
 MACH=ARM64xgene1 OS=ALL LVL=1000 COMPS=xcc
-   'gcc' '-ansi -O2'
+   'gcc' ' -O2'
 MACH=ARM64xgene1 OS=ALL LVL=1000 COMPS=icc
-   'gcc' '-ansi -mcpu=xgene1 -mtune=xgene1 -O2'
+   'gcc' ' -mcpu=xgene1 -mtune=xgene1 -O2'
 MACH=ARM64xgene1 OS=ALL LVL=1000 COMPS=skc,gcc,dkc
-   'gcc' '-ansi -mcpu=xgene1 -mtune=xgene1 -O3  -ftree-vect-loop-version -ftree-vectorize -fprefetch-loop-arrays'
+   'gcc' ' -mcpu=xgene1 -mtune=xgene1 -O3  -ftree-vect-loop-version -ftree-vectorize -fprefetch-loop-arrays'
 MACH=ARM64xgene1 OS=ALL LVL=1000 COMPS=smc
-   'gcc' '-ansi -O2 -mcpu=xgene1 -mtune=xgene1 -fprefetch-loop-arrays'
+   'gcc' ' -O2 -mcpu=xgene1 -mtune=xgene1 -fprefetch-loop-arrays'
 MACH=ARM64xgene1 OS=ALL LVL=1000 COMPS=dmc
-   'gcc' '-ansi -O1 -mcpu=xgene1 -mtune=xgene1 -fexpensive-optimizations -fprefetch-loop-arrays'
+   'gcc' ' -O1 -mcpu=xgene1 -mtune=xgene1 -fexpensive-optimizations -fprefetch-loop-arrays'
 MACH=ARM64xgene1 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-O2'
 #
@@ -320,13 +320,13 @@ MACH=ARM64xgene1 OS=ALL LVL=1000 COMPS=f77
 MACH=ARM64a57 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-mcpu=cortex-a57 -O2'
 MACH=ARM64a57 OS=ALL LVL=1000 COMPS=xcc
-   'gcc' '-ansi -mcpu=cortex-a57 -O2'
+   'gcc' ' -mcpu=cortex-a57 -O2'
 MACH=ARM64a57 OS=ALL LVL=1000 COMPS=icc
-   'gcc' '-ansi -mcpu=cortex-a57 -mtune=cortex-a57 -O2'
+   'gcc' ' -mcpu=cortex-a57 -mtune=cortex-a57 -O2'
 MACH=ARM64a57 OS=ALL LVL=1000 COMPS=skc,gcc,dkc
-   'gcc' '-ansi  -mcpu=cortex-a57 -mtune=cortex-a57 -O3'
+   'gcc' '  -mcpu=cortex-a57 -mtune=cortex-a57 -O3'
 MACH=ARM64a57 OS=ALL LVL=1100 COMPS=dmc,smc
-   'gcc' '-ansi -O1 -mcpu=cortex-a57 -mtune=cortex-a57'
+   'gcc' ' -O1 -mcpu=cortex-a57 -mtune=cortex-a57'
 MACH=ARM64a57 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-O2 -mcpu=cortex-a57'
 #
@@ -335,15 +335,15 @@ MACH=ARM64a57 OS=ALL LVL=1000 COMPS=f77
 MACH=ARM64a53 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-march=native -O2'
 MACH=ARM64a53 OS=ALL LVL=1000 COMPS=xcc
-   'gcc' '-ansi -march=native -O2'
+   'gcc' ' -march=native -O2'
 MACH=ARM64a53 OS=ALL LVL=1000 COMPS=icc
-   'gcc' '-ansi -mcpu=cortex-a53 -mtune=cortex-a53 -O2'
+   'gcc' ' -mcpu=cortex-a53 -mtune=cortex-a53 -O2'
 MACH=ARM64a53 OS=ALL LVL=1000 COMPS=skc,gcc,dkc
-   'gcc' '-ansi  -mcpu=cortex-a53 -mtune=cortex-a53 -O3  -ftree-vect-loop-version -ftree-vectorize'
+   'gcc' '  -mcpu=cortex-a53 -mtune=cortex-a53 -O3  -ftree-vect-loop-version -ftree-vectorize'
 MACH=ARM64a53 OS=ALL LVL=1000 COMPS=smc
-   'gcc' '-ansi -O2 -mcpu=cortex-a53 -mtune=cortex-a53'
+   'gcc' ' -O2 -mcpu=cortex-a53 -mtune=cortex-a53'
 MACH=ARM64a53 OS=ALL LVL=1000 COMPS=dmc
-   'gcc' '-ansi -O1 -mcpu=cortex-a53 -mtune=cortex-a53 -fexpensive-optimizations'
+   'gcc' ' -O1 -mcpu=cortex-a53 -mtune=cortex-a53 -fexpensive-optimizations'
 MACH=ARM64a53 OS=ALL LVL=1000 COMPS=f77
    'gfortran' '-O2 -mcpu=cortex-a53'
 #
@@ -361,7 +361,7 @@ MACH=XeonPHI OS=ALL LVL=1000 COMPS=f77
 MACH=ALL OS=ALL LVL=4 COMPS=smc,dmc,skc,dkc,icc,gcc,xcc
    'clang' '-O2'
 MACH=ALL OS=ALL LVL=5 COMPS=icc,smc,dmc,skc,dkc,xcc,gcc
-   'gcc' '-ansi -O -fomit-frame-pointer'
+   'gcc' ' -O -fomit-frame-pointer'
 MACH=ALL OS=ALL LVL=5 COMPS=f77
    'gfortran' '-O'
 MACH=ALL OS=ALL LVL=4 COMPS=f77


### PR DESCRIPTION
This flag broke feature detection for thread affinity. It depends on POSIX extensions being defined which are disabled by default unless compiling with --std=gnu90 which is the default when no standard is specified (-ansi is a standard)