### PR TITLE
Show errors

### DIFF
--- a/CONFIG/src/config.c
+++ b/CONFIG/src/config.c
@@ -56,7 +56,6 @@ int GetIntProbe(int verb, char *targarg, char *prb, char *id, int N)
    if (res)
    {
       iret = GetLastInt(res);
-      free(res);
    }
    if (N)
    {
@@ -66,6 +65,7 @@ int GetIntProbe(int verb, char *targarg, char *prb, char *id, int N)
          iret = 0;
       }
    }
+   free(res);
    return(iret);
 }
 

--- a/CONFIG/src/probe_aff.c
+++ b/CONFIG/src/probe_aff.c
@@ -31,10 +31,10 @@ int RunAffProbe(int iaff, int verb, char *targ, int iproc)
    if (targ)
    {
       i += strlen(targ);
-      frm = "make IRun_%s atlrun=atlas_runX targ=%s LIBS='%s' args='%d' 2> /dev/null | grep -F SUCCESS";
+      frm = "make IRun_%s atlrun=atlas_runX targ=%s LIBS='%s' args='%d' | grep -F SUCCESS";
    }
    else
-      frm = "make IRun_%s LIBS='%s' args='%d' 2> /dev/null | grep -F SUCCESS";
+      frm = "make IRun_%s LIBS='%s' args='%d' | grep -F SUCCESS";
    i += strlen(frm) + strlen(AFFS[iaff]) + strlen(lib) + 11;
    cmnd = malloc(sizeof(char)*i);
    assert(cmnd);

--- a/CONFIG/src/probe_asm.c
+++ b/CONFIG/src/probe_asm.c
@@ -7,11 +7,11 @@ int RunASMProbe(char *targ, int verb, enum OSTYPE OS, char *asmnam)
    int i = 0;
    if (targ)
    {
-      frm = "make IRun_%s atlrun=atlas_runX args=\"-v %d\" MYFLAGS=\"-DATL_OS_%s\" targ=%s 2> /dev/null | grep -F SUCCESS";
+      frm = "make IRun_%s atlrun=atlas_runX args=\"-v %d\" MYFLAGS=\"-DATL_OS_%s\" targ=%s | grep -F SUCCESS";
       i = strlen(targ);
    }
    else
-      frm = "make IRun_%s args=\"-v %d\" MYFLAGS=\"-DATL_OS_%s\" 2> /dev/null | grep -F SUCCESS";
+      frm = "make IRun_%s args=\"-v %d\" MYFLAGS=\"-DATL_OS_%s\" | grep -F SUCCESS";
 
    i += strlen(frm) + strlen(asmnam) + 11 + strlen(osnam[OS]) + 1;
    cmnd = malloc(i*sizeof(char));

--- a/CONFIG/src/probe_vec.c
+++ b/CONFIG/src/probe_vec.c
@@ -10,11 +10,11 @@ int RunISAProbe(char *isaxnam, int verb, char *targ, char *opt)
    int i=1;
    if (targ)
    {
-      frm = "make IRun_%s atlrun=atlas_runX targ=%s MYFLAGS='%s' 2> /dev/null | grep -F SUCCESS";
+      frm = "make IRun_%s atlrun=atlas_runX targ=%s MYFLAGS='%s' | grep -F SUCCESS";
       i += strlen(targ);
    }
    else
-      frm = "make IRun_%s MYFLAGS='%s' 2> /dev/null | grep -F SUCCESS";
+      frm = "make IRun_%s MYFLAGS='%s' | grep -F SUCCESS";
    i += strlen(frm) + strlen(isaxnam) + strlen(opt);
    cmnd = malloc(sizeof(char)*i);
    assert(cmnd);

--- a/include/atlas_sys.h
+++ b/include/atlas_sys.h
@@ -246,14 +246,14 @@ static FILE *atlsys(char *targ, char *cmnd, int verb, int IgnoreErr)
       i = strlen(targ) + strlen(cmnd) + strlen(tnam) + 24;
       sp = malloc(i*sizeof(char));
       assert(sp);
-      sprintf(sp, "ssh %s \"%s\" > %s %s \n", targ, cmnd, tnam, redir);
+      sprintf(sp, "ssh %s \"%s\" > %s %s", targ, cmnd, tnam, redir);
    }
    else
    {
       i = strlen(cmnd) + strlen(tnam) + 16;
       sp = malloc(i*sizeof(char));
       assert(sp);
-      sprintf(sp, "%s > %s %s\n", cmnd, tnam, redir);
+      sprintf(sp, "%s > %s %s", cmnd, tnam, redir);
    }
    i = system(sp);
    if (i && verb)


### PR DESCRIPTION
Instead of piping some commands to 2>/dev/null let them into the output so we can actually debug problems.
Fix a user-after-free.

Depends on #2 